### PR TITLE
Fixed an issue where textures could be missing when undo was used

### DIFF
--- a/src/Inspectors/Components/CubismRenderer.ts
+++ b/src/Inspectors/Components/CubismRenderer.ts
@@ -31,7 +31,7 @@ export async function update(this: IPanelThis, dump: IInputDump<ICubismRenderer>
   helper.color();
   helper.multiplyColor();
   helper.screenColor();
-  helper.material();
+  // helper.material();
   helper.mainTexture();
   helper.localOrder();
 
@@ -151,23 +151,23 @@ class UI extends InspectorComponentGuiHelper {
     this.parent.appendChild(prop);
   }
 
-  public material() {
-    const { material, node } = this.values;
-    const prop = this.createPropBase('Material');
-    const content = this.create(TagName.UI_ASSET);
-    content.slot = 'content';
-    content.droppable = 'cc.Material';
-    content.value = material.value.uuid;
-    content.addEventListener('confirm', async (_event) => {
-      await setProperty(node.value.uuid, material.path, {
-        value: { uuid: content.value ?? '' },
-        type: material.type,
-      });
-    });
+  // public material() {
+  //   const { material, node } = this.values;
+  //   const prop = this.createPropBase('Material');
+  //   const content = this.create(TagName.UI_ASSET);
+  //   content.slot = 'content';
+  //   content.droppable = 'cc.Material';
+  //   content.value = material.value.uuid;
+  //   content.addEventListener('confirm', async (_event) => {
+  //     await setProperty(node.value.uuid, material.path, {
+  //       value: { uuid: content.value ?? '' },
+  //       type: material.type,
+  //     });
+  //   });
 
-    prop.appendChild(content);
-    this.parent.appendChild(prop);
-  }
+  //   prop.appendChild(content);
+  //   this.parent.appendChild(prop);
+  // }
 
   public mainTexture() {
     const { mainTexture, node } = this.values;

--- a/static/assets/Rendering/CubismRenderer.ts
+++ b/static/assets/Rendering/CubismRenderer.ts
@@ -241,7 +241,7 @@ export default class CubismRenderer extends Component {
   //#endregion
 
   //#region Meshes
-  @property({ serializable: false, visible: false })
+  // @property({ serializable: false, visible: false })
   private _meshes: [CubismMeshPrimitive, CubismMeshPrimitive] = [
     CubismMeshPrimitive.makeEmpty(),
     CubismMeshPrimitive.makeEmpty(),
@@ -260,7 +260,7 @@ export default class CubismRenderer extends Component {
   //#endregion
 
   //#region FrontMesh
-  @property({ serializable: false, visible: false })
+  // @property({ serializable: false, visible: false })
   private _frontMesh: number = 0;
   /** Index of front buffer mesh. */
   private get frontMesh() {
@@ -272,7 +272,7 @@ export default class CubismRenderer extends Component {
   //#endregion
 
   //#region BackMesh
-  @property({ serializable: false, visible: false })
+  // @property({ serializable: false, visible: false })
   private _backMesh: number = 0;
   /** Index of back buffer mesh. */
   private get backMesh() {
@@ -293,7 +293,7 @@ export default class CubismRenderer extends Component {
 
   //#region MeshRenderer
   /** MeshRenderer backing field. */
-  @property({ serializable: false, visible: false })
+  // @property({ serializable: false, visible: false })
   private _meshRenderer: MeshRenderer | null = null;
   public get meshRenderer(): MeshRenderer | null {
     return this._meshRenderer;
@@ -408,7 +408,7 @@ export default class CubismRenderer extends Component {
   //#endregion
 
   //#region LastSwap
-  @property({ serializable: false, visible: false })
+  // @property({ serializable: false, visible: false })
   private _lastSwap: SwapInfo = SwapInfo.DEFAULT;
   /** Allows tracking of what vertex data was updated last swap. */
   private get lastSwap() {
@@ -420,7 +420,7 @@ export default class CubismRenderer extends Component {
   //#endregion
 
   //#region ThisSwap
-  @property({ serializable: false, visible: false })
+  // @property({ serializable: false, visible: false })
   private _thisSwap: SwapInfo = SwapInfo.DEFAULT;
   /** Allows tracking of what vertex data will be swapped. */
   private get thisSwap() {

--- a/static/assets/Rendering/CubismRenderer.ts
+++ b/static/assets/Rendering/CubismRenderer.ts
@@ -205,7 +205,7 @@ export default class CubismRenderer extends Component {
 
   //#region Material
   /** Material. */
-  @property({ type: Material, visible: true })
+  // @property({ type: Material, visible: true })
   public get material(): Material | null {
     return this.meshRenderer?.material ?? null;
   }


### PR DESCRIPTION
After we manipulate the prefab object, pressing ctrl+z in the scene will appear:
1. Material missing, showing Burgundy
2. After undo, true/false cannot be restored