### PR TITLE
[Bug] Fix the _size on CubismMaskTexture is undefined after build

### DIFF
--- a/static/assets/Rendering/Masking/CubismMaskTexture.ts
+++ b/static/assets/Rendering/Masking/CubismMaskTexture.ts
@@ -311,10 +311,17 @@ export default class CubismMaskTexture extends Asset implements ICubismMaskComma
   }
   // #endregion
 
-  private constructor(size: number, subdivisions: number) {
+  private constructor(size?: number, subdivisions?: number) {
     super();
-    this._size = size;
-    this._subdivisions = subdivisions;
+    // Parameters cannot be given during deserialization, so none of the parameters in the constructor may be present
+    // The build process removes the same data as the default value.
+    // So if no parameters are passed in and no data is restored, the default values on the class are used
+    if (size !== undefined) {
+      this._size = size;
+    }
+    if (subdivisions !== undefined) {
+      this._subdivisions = subdivisions;
+    }
   }
 
   public static generateCubismMaskTexture(


### PR DESCRIPTION
All data that needs to be deserialized, their constructors cannot have fixed parameters.
This is because the default parameters cannot be given during deserialization.

All data will be restored after normal deserialization.
Here it happens that this data is excluded because the post-construction recognition _size is equal to the default value, so the data is not recovered properly after the construction.